### PR TITLE
Update URLs to renamed github repo

### DIFF
--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -8,7 +8,7 @@
 // @downloadURL  https://github.com/Minigamer42/scripts/raw/master/src/amq%20song%20history%20(with%20localStorage).user.js
 // @updateURL    https://github.com/Minigamer42/scripts/raw/master/src/amq%20song%20history%20(with%20localStorage).user.js
 // @grant        none
-// @require      https://raw.githubusercontent.com/TheJoseph98/AMQ-Scripts/master/common/amqScriptInfo.js
+// @require      https://github.com/joske2865/AMQ-Scripts/raw/master/common/amqScriptInfo.js
 // @require      https://github.com/Minigamer42/scripts/raw/master/lib/commands.js
 // ==/UserScript==
 

--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         amq song history (with localStorage)
 // @namespace    http://tampermonkey.net/
-// @version      1.4
+// @version      1.5
 // @description  Display Song history in the song info box, including the guess rate and time since last time the song played.
 // @author       Minigamer42
 // @match        https://animemusicquiz.com/*

--- a/src/amqNewGameModeUISonicHeroes.user.js
+++ b/src/amqNewGameModeUISonicHeroes.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AMQ New Game Mode UI Sonic Heroes
 // @namespace    https://github.com/Minigamer42
-// @version      0.21
+// @version      0.22
 // @description  Adds a user interface to new game mode to keep track of guesses
 // @author       Minigamer42
 // @match        https://animemusicquiz.com/*

--- a/src/amqNewGameModeUISonicHeroes.user.js
+++ b/src/amqNewGameModeUISonicHeroes.user.js
@@ -6,8 +6,8 @@
 // @author       Minigamer42
 // @match        https://animemusicquiz.com/*
 // @grant        none
-// @require      https://raw.githubusercontent.com/TheJoseph98/AMQ-Scripts/master/common/amqScriptInfo.js
-// @require      https://raw.githubusercontent.com/TheJoseph98/AMQ-Scripts/master/common/amqWindows.js
+// @require      https://github.com/joske2865/AMQ-Scripts/raw/master/common/amqScriptInfo.js
+// @require      https://github.com/joske2865/AMQ-Scripts/raw/master/common/amqWindows.js
 // @require      https://github.com/amq-script-project/AMQ-Scripts/raw/master/gameplay/amqAnswerTimesUtility.user.js
 // @downloadURL  https://github.com/Minigamer42/scripts/raw/master/src/amqNewGameModeUISonicHeroes.user.js
 // @updateURL  https://github.com/Minigamer42/scripts/raw/master/src/amqNewGameModeUISonicHeroes.user.js


### PR DESCRIPTION
Unsure why, may depend on loading order in tampermonkey, all other scripts that had updated these references already, stopped working recently for me.
Changing this one to have the new repo URL made all of them work again 🤷 

Only found these 3 in your repo, hope I didn't miss any, not on my usual setup.