### PR TITLE
Bug fix: amq song history (with localStorage)

### DIFF
--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         amq song history (with localStorage)
 // @namespace    http://tampermonkey.net/
-// @version      1.6
+// @version      1.7
 // @description  Display Song history in the song info box, including the guess rate and time since last time the song played.
 // @author       Minigamer42
 // @match        https://animemusicquiz.com/*
@@ -12,7 +12,7 @@
 // @require      https://github.com/Minigamer42/scripts/raw/master/lib/commands.js
 // ==/UserScript==
 
-const version = "1.6";
+const version = "1.7";
 const infoDiv = document.createElement('div');
 infoDiv.className = "rowPlayCount";
 infoDiv.style.marginBottom = "10px";

--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -104,7 +104,7 @@ function setup() {
             isCorrect = quiz.isSpectator ? false : data.players.find(player => player.gamePlayerId === quiz.ownGamePlayerId)?.correct;
         }
         current.correctCount += isCorrect;
-        current.spectatorCount += quiz.isSpectator;
+        current.spectatorCount += quiz.isSpectator ? 1 : 0;
         localStorage.setItem('songHistory', JSON.stringify({
             ...songHistory,
             [webm]: {

--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -101,9 +101,9 @@ function setup() {
         if (quiz.gameMode === "Nexus") {
             isCorrect = data.players[0]?.correct;
         } else {
-            isCorrect = quiz.isSpectator ? false : data.players.find(player => player.gamePlayerId === quiz.ownGamePlayerId)?.correct;
+            isCorrect = quiz.isSpectator ? false : !!data.players[quiz.ownGamePlayerId]?.correct;
         }
-        current.correctCount += isCorrect;
+        current.correctCount += isCorrect ? 1 : 0;
         current.spectatorCount += quiz.isSpectator ? 1 : 0;
         localStorage.setItem('songHistory', JSON.stringify({
             ...songHistory,

--- a/src/amq song history (with localStorage).user.js
+++ b/src/amq song history (with localStorage).user.js
@@ -97,14 +97,17 @@ function setup() {
         const songHistory = JSON.parse(localStorage.getItem('songHistory'));
         const current = songHistory[webm] ?? {count: 0, correctCount: 0.0, spectatorCount: 0, lastPlayed: 0};
         current.count++;
+        let isSpectator;
         let isCorrect;
         if (quiz.gameMode === "Nexus") {
             isCorrect = data.players[0]?.correct;
         } else {
-            isCorrect = quiz.isSpectator ? false : !!data.players[quiz.ownGamePlayerId]?.correct;
+            const playerData = data.players.find(player => player.gamePlayerId === quiz.ownGamePlayerId);
+            isSpectator = !playerData
+            isCorrect = !!playerData?.correct;
         }
         current.correctCount += isCorrect ? 1 : 0;
-        current.spectatorCount += quiz.isSpectator ? 1 : 0;
+        current.spectatorCount += isSpectator ? 1 : 0;
         localStorage.setItem('songHistory', JSON.stringify({
             ...songHistory,
             [webm]: {


### PR DESCRIPTION
_This PR only makes changes to the Song History script._

Seemingly there have been some issues with the `spectatorCount` variable being `NaN` in certain scenarios ([someone mentioned this recently in the discord](https://discord.com/channels/386089398975856641/989576545913933924/1353815900087779431)). This also causes the `correctRatio` to not be displayed since `spectatorCount` being `NaN` blocks the stuff around [line 121](https://github.com/Minigamer42/scripts/blob/5d4016549fc06ec31d52a5958cd35c772d405cf1/src/amq%20song%20history%20(with%20localStorage).user.js#L121).

The issue seems to be caused by `quiz.isSpectator` always being `undefined` during the quiz if joining a ranked/themed lobby before the quiz itself starting. 